### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -27,7 +27,7 @@ final class ClientTest extends TestCase
     /** @var array */
     private $matchers = [];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $apiKey = getenv('KRAKEN_API_KEY');
         $apiSecret = getenv('KRAKEN_API_SECRET');


### PR DESCRIPTION
According to the [official PHPunit doc](https://phpunit.readthedocs.io/en/9.5/fixtures.html?highlight=fixtures#fixtures), it should be `protected function setUp(): void`.